### PR TITLE
Fix/load text domain

### DIFF
--- a/admin/class-featured-image-admin-thumb-admin.php
+++ b/admin/class-featured-image-admin-thumb-admin.php
@@ -69,7 +69,6 @@ class Featured_Image_Admin_Thumb_Admin {
 		 */
 		$plugin              = Featured_Image_Admin_Thumb::get_instance();
 		$this->plugin_slug   = $plugin->get_plugin_slug();
-		$this->template_html = '<a title="' . __( 'Change featured image', 'featured-image-admin-thumb-fiat' ) . '" href="%1$s" class="fiat_thickbox" data-thumbnail-id="%3$d">%2$s</a>';
 		$this->fiat_kses     = array(
 			'a'   => array(
 				'href'              => array(),
@@ -99,11 +98,22 @@ class Featured_Image_Admin_Thumb_Admin {
 		}
 
 		add_action( 'admin_init', array( $this, 'fiat_init_columns' ) );
+		add_action( 'admin_init', array( $this, 'fiat_set_template_html' ) );
 
 		add_action( 'wp_ajax_fiat_get_thumbnail', array( $this, 'fiat_get_thumbnail' ) );
 
 		add_action( 'pre_get_posts', array( $this, 'fiat_posts_orderby' ) );
 	}
+
+	/**
+	 * Set the admin html template with language support
+	 *
+	 * Fired in the 'admin_init' action
+	 */
+	public function fiat_set_template_html() {
+		$this->template_html = '<a title="' . __( 'Change featured image', 'featured-image-admin-thumb-fiat' ) . '" href="%1$s" class="fiat_thickbox" data-thumbnail-id="%3$d">%2$s</a>';
+	}
+
 	/**
 	 * Register admin column handlers for posts and pages, taxonomies and other custom post types
 	 *

--- a/admin/class-featured-image-admin-thumb-admin.php
+++ b/admin/class-featured-image-admin-thumb-admin.php
@@ -44,7 +44,6 @@ class Featured_Image_Admin_Thumb_Admin {
 	 */
 
 	protected $fiat_nonce = null;
-	protected $text_domain;
 	protected $fiat_image_size = 'fiat_thumb';
 	protected $is_woocommerce_active;
 	protected $is_ninja_forms_active;
@@ -70,7 +69,6 @@ class Featured_Image_Admin_Thumb_Admin {
 		 */
 		$plugin              = Featured_Image_Admin_Thumb::get_instance();
 		$this->plugin_slug   = $plugin->get_plugin_slug();
-		$this->text_domain   = $plugin->load_plugin_textdomain();
 		$this->template_html = '<a title="' . __( 'Change featured image', 'featured-image-admin-thumb-fiat' ) . '" href="%1$s" class="fiat_thickbox" data-thumbnail-id="%3$d">%2$s</a>';
 		$this->fiat_kses     = array(
 			'a'   => array(

--- a/featured-image-admin-thumb.php
+++ b/featured-image-admin-thumb.php
@@ -56,5 +56,14 @@ add_action( 'plugins_loaded',           array( 'Featured_Image_Admin_Thumb', 'ge
 if ( is_admin() ) {
 	require_once( plugin_dir_path( __FILE__ ) . 'admin/class-featured-image-admin-thumb-admin.php' );
 	add_action( 'plugins_loaded', array( 'Featured_Image_Admin_Thumb_Admin', 'get_instance' ) );
-
+	add_action(
+		'init',
+		static function (){
+			load_plugin_textdomain(
+				'featured-image-admin-thumb-fiat',
+				false,
+				dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+			);
+		}
+	);
 }

--- a/public/class-featured-image-admin-thumb.php
+++ b/public/class-featured-image-admin-thumb.php
@@ -63,9 +63,6 @@ class Featured_Image_Admin_Thumb {
 	 */
 	private function __construct() {
 
-		// Load plugin text domain
-		add_action( 'init',                 array( $this, 'load_plugin_textdomain' ) );
-
 		// Activate plugin when new blog is added
 		add_action( 'wpmu_new_blog',        array( $this, 'activate_new_site' ) );
 
@@ -232,20 +229,6 @@ class Featured_Image_Admin_Thumb {
 	 */
 	private static function single_deactivate() {
 		// @TODO: Define deactivation functionality here
-	}
-
-	/**
-	 * Load the plugin text domain for translation.
-	 *
-	 * @since    1.0.0
-	 */
-	public function load_plugin_textdomain() {
-
-		load_plugin_textdomain(
-				$this->plugin_slug,
-				false,
-				dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
-		);
 	}
 
 	/**


### PR DESCRIPTION
#### Summary

Referring to reports of notices showing in logs related to running functions to load textdomain too early in the WordPress flow this PR removes a custom function, related class properties

##### Support tickets referencing the issues
https://wordpress.org/support/topic/error-notices-for-featured-image-admin-thumb-after-wordpress-6-7-1-update/
https://wordpress.org/support/topic/bug-report-for-latest-updates-wordpress-6-8-fiat-1-6/